### PR TITLE
replace cocaine with terrapin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in paperclip-av-transcoder.gemspec
 gemspec
+gem 'av', git: 'https://github.com/Leevia/av.git', tag: 'v0.9.2' # Not well maintained gem

--- a/lib/paperclip/paperclip_processors/transcoder.rb
+++ b/lib/paperclip/paperclip_processors/transcoder.rb
@@ -75,7 +75,7 @@ module Paperclip
         begin
           @cli.run
           log "Successfully transcoded #{@basename} to #{dst}"
-        rescue Cocaine::ExitStatusError => e
+        rescue Terrapin::ExitStatusError => e
           raise Paperclip::Error, "error while transcoding #{@basename}: #{e}" if @whiny
         end
       else

--- a/paperclip-av-transcoder.gemspec
+++ b/paperclip-av-transcoder.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", "~> 2.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0.0"
   spec.add_development_dependency "rails", ">= 4.0.0"


### PR DESCRIPTION
The goal of this PR is to completely remove dependency on deprecated gem `cocaine` and use the new gem `terrapin`.

Contents:
- update bundler version
- use gem `av` from Leevia repository (that already use `terrapin`)
- replace `cocaine` with `terrapin`